### PR TITLE
Update module dependencies to grunt 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.2.0",
-    "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.0",
-    "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-clean": "~0.5.0"
+    "grunt": "^1.0.1",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "^1.0.1"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
This updates the module dependencies in order to make grunt-bom-removal ready for use with current versions of grunt.
As far as I can see, everything still works as expected.

@zandroid: Note that this does not yet change the module's version number - but it would be great, if you could update the version and push the new version to the npm registry!