### PR TITLE
Update readme to match the used grunt version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 As a note it does a direct rewrite of the file, just without the BOM, please make sure you have tested grunt-bom-removal before using it any code, just in case for some reason it decides to eat your code for lunch.
 
 ## Getting Started
-This plugin requires Grunt `~0.4.0`
+This plugin requires Grunt `~1.0.0`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -20,7 +20,7 @@ Once the plugin has been installed, it may be enabled inside your Gruntfile with
 grunt.loadNpmTasks('grunt-bom-removal');
 ```
 
-*This plugin was designed to work with Grunt 0.4.x. If you're still using grunt v0.3.x it's strongly recommended that [you upgrade](http://gruntjs.com/upgrading-from-0.3-to-0.4).*
+*This plugin was designed to work with Grunt 1.0.x. If you're still using an older version it's strongly recommended that [you upgrade](http://gruntjs.com/upgrading-from-0.4-to-1.0).*
 
 ## BOM task
 _Run this task with the `grunt bom` command._


### PR DESCRIPTION
A little thing we missed in the last PR: The readme still stated, that the plugin is used for grunt 0.4.0 - which is no longer true.